### PR TITLE
Removed hardcoding of 'eu-west-1' for the IoT endpoint and use the AWS_REGION variable.

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -10,7 +10,7 @@ S3_BUCKET=${3:?Usage: deploy.sh <stack_name> <aws_region> <s3_bucket>}
 mkdir -p tmp
 
 echo Fetching IoT endpoint URL
-AWS_IOT_ENDPOINT=`aws iot describe-endpoint --region eu-west-1 | perl -lne 'print $1 if /"endpointAddress": "([^"]+)"/'`
+AWS_IOT_ENDPOINT=`aws iot describe-endpoint --region ${AWS_REGION} | perl -lne 'print $1 if /"endpointAddress": "([^"]+)"/'`
 
 echo Checking S3 bucket
 if ! aws s3 ls s3://${S3_BUCKET} >/dev/null; then


### PR DESCRIPTION
When deploying the stack in a region other than 'eu-west-1', you would get a 403 on the frontend for the WebSocket handshake. This change resolves that issue.